### PR TITLE
removes annoying warning

### DIFF
--- a/numgrid/lebedev/sphere_lebedev_rule.cpp
+++ b/numgrid/lebedev/sphere_lebedev_rule.cpp
@@ -6487,6 +6487,14 @@ void timestamp ( void )
   tm = localtime ( &now );
 
   len = strftime ( time_buffer, TIME_SIZE, "%d %B %Y %I:%M:%S %p", tm );
+  if (len == 0)
+  {
+    fprintf ( stderr, "\n" );
+    fprintf ( stderr, "TIMESTAMP - Fatal error!\n" );
+    fprintf ( stderr, "  TIME_SIZE constant too small.\n" );
+    exit ( 1 );
+  }
+ 
 
   fprintf ( stdout, "%s\n", time_buffer );
 


### PR DESCRIPTION
When compiling, I get a warning:

```
[ 31%] Building CXX object numgrid/CMakeFiles/numgrid-objects.dir/lebedev/sphere_lebedev_rule.cpp.o
/home/scemama/Downloads/numgrid/numgrid/lebedev/sphere_lebedev_rule.cpp: In function ‘void timestamp()’:
/home/scemama/Downloads/numgrid/numgrid/lebedev/sphere_lebedev_rule.cpp:6483:10: warning: variable ‘len’ set but not used [-Wunused-but-set-variable]
   size_t len;
          ^~~
```

len can be used to check that there was no overflow, and this removes the warning.

Labels:
- warning

## Description
`len` is now used to check that the buffer was large enough.

## Motivation and Context
Warnings are very annoying for users

## How Has This Been Tested?
The code was installed, compiled with no warning and the cpp_test program has been run.

## Screenshots (if appropriate):
None

## Todos
Nothing.
* **Developer Interest**
<!--- Changes affecting developers -->
  - None
* **User-Facing for Release Notes**
<!--- Changes affecting users -->
  - None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions
- None

## Status
- [ ]  Ready to go


